### PR TITLE
Adjusting max_attempts to 30

### DIFF
--- a/enumerate_iam/main.py
+++ b/enumerate_iam/main.py
@@ -110,8 +110,7 @@ def get_client(access_key, secret_key, session_token, service_name, region):
 
     config = Config(connect_timeout=5,
                     read_timeout=5,
-                    max_attempts=30,
-                    retries={'max_attempts': 1},
+                    retries={'max_attempts': 30},
                     max_pool_connections=MAX_POOL_CONNECTIONS * 2)
 
     try:


### PR DESCRIPTION
Adjusting max_attempts to 30 to mitigate AWS rate limit. It should mitigate following issue: https://github.com/andresriancho/enumerate-iam/issues/1