### PR TITLE
Modified code to work with both Python 3 and Python 2

### DIFF
--- a/enumerate_iam/check_version.py
+++ b/enumerate_iam/check_version.py
@@ -1,9 +1,0 @@
-import sys
-
-def check_version():
-    if sys.version_info[0] < 3:
-        return 2
-    else:
-        return 3
-
-PYTHON_VERSION = check_version()

--- a/enumerate_iam/check_version.py
+++ b/enumerate_iam/check_version.py
@@ -1,0 +1,9 @@
+import sys
+
+def check_version():
+    if sys.version_info[0] < 3:
+        return 2
+    else:
+        return 3
+
+PYTHON_VERSION = check_version()

--- a/enumerate_iam/generate_bruteforce_tests.py
+++ b/enumerate_iam/generate_bruteforce_tests.py
@@ -1,7 +1,7 @@
 import re
 import os
 import json
-
+from enumerate_iam.check_version import *
 
 OUTPUT_FMT = 'BRUTEFORCE_TESTS = %s'
 OUTPUT_FILE = 'bruteforce_tests.py'
@@ -64,7 +64,13 @@ def is_dangerous(operation_name):
 def extract_operations(api_json):
     operations = []
 
-    for operation_name, operation_data in api_json['operations'].iteritems():
+    if PYTHON_VERSION == 2:
+        items = api_json['operations'].iteritems()
+    else:
+        # Python 3
+        items = api_json['operations'].items()
+
+    for operation_name, operation_data in items:
         operation_name = to_underscore(operation_name)
 
         if is_dangerous(operation_name):
@@ -103,7 +109,13 @@ def main():
         if not filename.endswith('.min.json'):
             continue
 
-        api_json_data = file(os.path.join(API_DEFINITIONS, filename)).read()
+        if PYTHON_VERSION == 2:
+            #print("Py 2")
+            api_json_data = file(os.path.join(API_DEFINITIONS, filename)).read()
+        else:
+            #print("Py 3")
+            api_json_data = open(os.path.join(API_DEFINITIONS, filename)).read()
+
         api_json = json.loads(api_json_data)
 
         service_name = extract_service_name(filename, api_json)
@@ -126,7 +138,12 @@ def main():
                                      indent=4,
                                      sort_keys=True)
 
-    file(OUTPUT_FILE, 'w').write(output)
+
+    if PYTHON_VERSION == 2:
+        file(OUTPUT_FILE, 'w').write(output)
+    else:
+        # Python 3
+        open(OUTPUT_FILE, 'w').write(output)
 
 
 if __name__ == '__main__':

--- a/enumerate_iam/generate_bruteforce_tests.py
+++ b/enumerate_iam/generate_bruteforce_tests.py
@@ -1,7 +1,6 @@
 import re
 import os
 import json
-from enumerate_iam.check_version import *
 
 OUTPUT_FMT = 'BRUTEFORCE_TESTS = %s'
 OUTPUT_FILE = 'bruteforce_tests.py'
@@ -64,11 +63,7 @@ def is_dangerous(operation_name):
 def extract_operations(api_json):
     operations = []
 
-    if PYTHON_VERSION == 2:
-        items = api_json['operations'].iteritems()
-    else:
-        # Python 3
-        items = api_json['operations'].items()
+    items = api_json['operations'].items()
 
     for operation_name, operation_data in items:
         operation_name = to_underscore(operation_name)
@@ -109,12 +104,7 @@ def main():
         if not filename.endswith('.min.json'):
             continue
 
-        if PYTHON_VERSION == 2:
-            #print("Py 2")
-            api_json_data = file(os.path.join(API_DEFINITIONS, filename)).read()
-        else:
-            #print("Py 3")
-            api_json_data = open(os.path.join(API_DEFINITIONS, filename)).read()
+        api_json_data = open(os.path.join(API_DEFINITIONS, filename)).read()
 
         api_json = json.loads(api_json_data)
 
@@ -138,12 +128,7 @@ def main():
                                      indent=4,
                                      sort_keys=True)
 
-
-    if PYTHON_VERSION == 2:
-        file(OUTPUT_FILE, 'w').write(output)
-    else:
-        # Python 3
-        open(OUTPUT_FILE, 'w').write(output)
+    open(OUTPUT_FILE, 'w').write(output)
 
 
 if __name__ == '__main__':

--- a/enumerate_iam/main.py
+++ b/enumerate_iam/main.py
@@ -31,6 +31,8 @@ from enumerate_iam.utils.remove_metadata import remove_metadata
 from enumerate_iam.utils.json_utils import json_encoder
 from enumerate_iam.bruteforce_tests import BRUTEFORCE_TESTS
 
+from enumerate_iam.check_version import *
+
 
 MAX_THREADS = 25
 CLIENT_POOL = {}
@@ -87,7 +89,13 @@ def enumerate_using_bruteforce(access_key, secret_key, session_token, region):
 
 
 def generate_args(access_key, secret_key, session_token, region):
-    service_names = BRUTEFORCE_TESTS.keys()
+
+    if PYTHON_VERSION == 2:
+        service_names = BRUTEFORCE_TESTS.keys()
+    else:
+        # Python 3
+        service_names = list(BRUTEFORCE_TESTS.keys())
+
     random.shuffle(service_names)
 
     for service_name in service_names:

--- a/enumerate_iam/main.py
+++ b/enumerate_iam/main.py
@@ -31,9 +31,6 @@ from enumerate_iam.utils.remove_metadata import remove_metadata
 from enumerate_iam.utils.json_utils import json_encoder
 from enumerate_iam.bruteforce_tests import BRUTEFORCE_TESTS
 
-from enumerate_iam.check_version import *
-
-
 MAX_THREADS = 25
 CLIENT_POOL = {}
 
@@ -90,11 +87,7 @@ def enumerate_using_bruteforce(access_key, secret_key, session_token, region):
 
 def generate_args(access_key, secret_key, session_token, region):
 
-    if PYTHON_VERSION == 2:
-        service_names = BRUTEFORCE_TESTS.keys()
-    else:
-        # Python 3
-        service_names = list(BRUTEFORCE_TESTS.keys())
+    service_names = list(BRUTEFORCE_TESTS.keys())
 
     random.shuffle(service_names)
 


### PR DESCRIPTION
The enumerate-iam.py script was throwing errors when I tried using it to enumerate the identity pool permissions granted to the unauthenticated user role. I realized that I had Python 3 installed, and that the enumerate-iam scripts were written for Python 2. 

I have added a check for identifying the Python version installed in the host system. The modified code will work regardless of whether the user has Python 2 or Python 3 installed in the host machine.