### PR TITLE
Added support for AWS Credentials profiles and enhanced Ctrl-C handling

### DIFF
--- a/enumerate-iam.py
+++ b/enumerate-iam.py
@@ -1,24 +1,42 @@
 #!/usr/bin/env python
+import sys
 import argparse
 
+from boto3 import Session
 from enumerate_iam.main import enumerate_iam
-
 
 def main():
     parser = argparse.ArgumentParser(description='Enumerate IAM permissions')
 
-    parser.add_argument('--access-key', help='AWS access key', required=True)
-    parser.add_argument('--secret-key', help='AWS secret key', required=True)
+    parser.add_argument('--profile', help='AWS profile name fetched from credentials file. Specify this parameter or access-key and secret-key manually.')
+    parser.add_argument('--access-key', help='AWS access key if profile was not used')
+    parser.add_argument('--secret-key', help='AWS secret key if profile was not used')
     parser.add_argument('--session-token', help='STS session token')
     parser.add_argument('--region', help='AWS region to send API requests to', default='us-east-1')
 
     args = parser.parse_args()
 
-    enumerate_iam(args.access_key,
-                  args.secret_key,
-                  args.session_token,
-                  args.region)
+    if args.profile and (args.access_key or args.secret_key or args.session_token):
+        sys.stderr.write('error: Profile and raw AWS credential options are mutually exclusive.\n')
+        sys.stderr.write('       Please specify either --profile or --access-key and --secret-key.\n')
+        sys.exit(2)
 
+    access_key = args.access_key
+    secret_key = args.secret_key
+    session_token = args.session_token
+
+    if args.profile:
+        session = Session(profile_name = args.profile)
+        credentials = session.get_credentials()
+        currcreds = credentials.get_frozen_credentials()
+        access_key = currcreds.access_key
+        secret_key = currcreds.secret_key
+        session_token = currcreds.token
+
+    enumerate_iam(access_key,
+                  secret_key,
+                  session_token,
+                  args.region)
 
 if __name__ == '__main__':
     main()

--- a/enumerate-iam.py
+++ b/enumerate-iam.py
@@ -1,9 +1,12 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
+import json
+import logging
 import argparse
 
 from boto3 import Session
 from enumerate_iam.main import enumerate_iam
+from enumerate_iam.utils.json_utils import json_encoder
 
 def main():
     parser = argparse.ArgumentParser(description='Enumerate IAM permissions')
@@ -13,6 +16,10 @@ def main():
     parser.add_argument('--secret-key', help='AWS secret key if profile was not used')
     parser.add_argument('--session-token', help='STS session token')
     parser.add_argument('--region', help='AWS region to send API requests to', default='us-east-1')
+    parser.add_argument('--output', help='File to write output JSON containing all of the collected permissions')
+    parser.add_argument('--timeout', help='Timeout in minutes for permissions brute-forcing activity. Def: 15.', type=int, default=15)
+    #parser.add_argument('--verbose', action='store_true', help='Enable verbose output.')
+    parser.add_argument('--debug', action='store_true', help='Enable debug output.')
 
     args = parser.parse_args()
 
@@ -34,10 +41,20 @@ def main():
         secret_key = currcreds.secret_key
         session_token = currcreds.token
 
-    enumerate_iam(access_key,
+    level = logging.INFO
+    if args.debug:
+        level = logging.DEBUG
+
+    output = enumerate_iam(access_key,
                   secret_key,
                   session_token,
-                  args.region)
+                  args.region,
+                  args.timeout * 60,
+                  level)
+
+    if args.output:
+        with open(args.output, 'w') as f:
+            f.write(json.dumps(output, indent=4, default=json_encoder))
 
 if __name__ == '__main__':
     main()

--- a/enumerate-iam.py
+++ b/enumerate-iam.py
@@ -18,7 +18,8 @@ def main():
 
     if args.profile and (args.access_key or args.secret_key or args.session_token):
         sys.stderr.write('error: Profile and raw AWS credential options are mutually exclusive.\n')
-        sys.stderr.write('       Please specify either --profile or --access-key and --secret-key.\n')
+        sys.stderr.write('       Please specify either --profile or --access-key and --secret-key.\n\n')
+        parser.print_help()
         sys.exit(2)
 
     access_key = args.access_key

--- a/enumerate_iam/utils/json_utils.py
+++ b/enumerate_iam/utils/json_utils.py
@@ -5,13 +5,11 @@ import collections
 
 DEFAULT_ENCODING = 'utf-8'
 
-
 def map_nested_dicts(ob, func):
     if isinstance(ob, collections.Mapping):
         return {k: map_nested_dicts(v, func) for k, v in ob.iteritems()}
     else:
         return func(ob)
-
 
 def json_encoder(o):
     if type(o) is datetime.date or type(o) is datetime.datetime:


### PR DESCRIPTION
This commit introduced support for `--profile` argument for those who has multiple AWS credentials stored creds file with dedicated profile name labels. Also, since `Pool.map` is a blocking operation,  found Ctrl-C not working anytime I hit it. Therefore a minor work was done to switch parallel execution to `map_async` approach, while introducing general timeout of 600 seconds and reinforcing SIGINT handler accoriding to the following recipe:

https://stackoverflow.com/questions/11312525/catch-ctrlc-sigint-and-exit-multiprocesses-gracefully-in-python

Best regards,
M.