### PR TITLE
Use git clone with "--depth=1" to fetch AWS SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ finding all the existing permissions run:
 
 ```console
 cd enumerate_iam/
-git clone https://github.com/aws/aws-sdk-js.git
+git clone --depth=1 https://github.com/aws/aws-sdk-js.git
 python generate_bruteforce_tests.py
 rm -rf aws-sdk-js
 ```


### PR DESCRIPTION
We don't need git history and it's faster!